### PR TITLE
Added Windows support - install pyreadline when on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     license = "BSD",
     keywords = "cloud CLI REST admin administrator node vultr",
     install_requires=["requests","argparse"],
+    extras_require={':sys_platform == "win32"': ['pyreadline']},
     url = "https://github.com/yikaus/vultrcli",   # project home page, if any
 
     # could also include long_description, download_url, classifiers, etc.

--- a/vucli/vucli.py
+++ b/vucli/vucli.py
@@ -19,7 +19,10 @@ import sys
 import os
 import argparse
 #import simplejson as json
-import readline
+try:
+  import readline
+except ImportError:
+  import pyreadline as readline
 
 API_BASE_URL = "https://api.vultr.com/v1/"
 REGIONS_AVAILABILITY_URL = ""


### PR DESCRIPTION
I wanted to use the CLI on Windows. Because of the readline dependency it would not work. With pyreadline it also works on Windows.

This pull request modifies the setup to install pyreadline when on Windows. It then imports pyreadline when there is an import error when importing readline.